### PR TITLE
added missing include tag

### DIFF
--- a/tests/CalculatorTest.php
+++ b/tests/CalculatorTest.php
@@ -1,6 +1,8 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
+include("./src/Calculator.php");
+
 final class CalculatorTest extends TestCase
 {
     public function testCanBeCreatedFromConstructor(): void{


### PR DESCRIPTION
Tests didn't find the Calculator class because the include tag was missing. Added the tag: " include("./src/Calculator.php"); ".

Beniamino